### PR TITLE
Fix bad memory access on modulus and exponent

### DIFF
--- a/src/keychain_pkcs11.c
+++ b/src/keychain_pkcs11.c
@@ -4517,13 +4517,15 @@ build_id_objects(struct slot_entry *entry)
 		 */
 
 		if (keydata) {
-			ADD_ATTR_SIZE(entry->obj_list, entry->obj_count,
-				      CKA_MODULUS, CFDataGetBytePtr(modulus),
-				      CFDataGetLength(modulus));
-			ADD_ATTR_SIZE(entry->obj_list, entry->obj_count,
-				      CKA_PUBLIC_EXPONENT,
-				      CFDataGetBytePtr(exponent),
-				      CFDataGetLength(exponent));
+			if (modulus)
+				ADD_ATTR_SIZE(entry->obj_list, entry->obj_count,
+						CKA_MODULUS, CFDataGetBytePtr(modulus),
+						CFDataGetLength(modulus));
+			if (exponent)
+				ADD_ATTR_SIZE(entry->obj_list, entry->obj_count,
+						CKA_PUBLIC_EXPONENT,
+						CFDataGetBytePtr(exponent),
+						CFDataGetLength(exponent));
 		}
 
 		b = CK_TRUE;


### PR DESCRIPTION
Hi Ken,

I added some guard statements before adding the modulus and exponent. I am having an issue where the keychain-pkcs11 library segfaults when I plug in a security key with a code signing certificate on it. The `get_pubkey_info` function returns `false` and the exponent and modulus variables are never set. However later on those variables are set on the private key object which then causes a segfault. 

Let me know what you think?

 